### PR TITLE
Went through all files and compared assembler comments to actual implemenation and added missing parameters

### DIFF
--- a/src/eos.h
+++ b/src/eos.h
@@ -158,7 +158,7 @@ unsigned char eos_switch_memory_banks(unsigned char bconfig);
 #define eos_cons_out          eos_console_display_special
 
 void eos_console_init(unsigned char cols, unsigned char rows, unsigned char left, unsigned char top, unsigned short addr);
-void eos_console_display_regular(char c);
+void eos_console_display_regular(char c, unsigned char col, unsigned char row);
 void eos_console_display_special(char c, unsigned char col, unsigned char row);
 
 /* Printer Interface */
@@ -202,10 +202,10 @@ unsigned char eos_end_read_keyboard(void);
 #define eos_init_tape_dir     eos_initialize_directory
 #define eos_set_date          eos_put_date
 
-FCB* eos_file_manager_init(void *fcb_buf);
-unsigned char eos_check_directory_for_file(const char *filename, unsigned long *block);
-unsigned char eos_find_file_1(const char *filename, DirectoryEntry *entry, unsigned long *block);
-unsigned char eos_find_file_2(const char *filename, DirectoryEntry *entry, unsigned long *block);
+void eos_file_manager_init(void *fcb_buf, void *fcs_buf);
+unsigned char eos_check_directory_for_file(const char *filename, unsigned long *block, unsigned char device_number);
+unsigned char eos_find_file_1(const char *filename, DirectoryEntry *entry, unsigned long *block, unsigned char device_number);
+unsigned char eos_find_file_2(const char *filename, DirectoryEntry *entry, unsigned long *block, unsigned char device_number);
 unsigned char eos_find_file_in_fcb(const char *filename, unsigned char *filemode, FCB *fcb);
 unsigned char eos_check_file_mode(const char *filename, FCB *fcb);
 unsigned char eos_make_file(unsigned char dev, const char *filename, unsigned long size);

--- a/src/eos.h
+++ b/src/eos.h
@@ -319,4 +319,34 @@ void eos_decrement_high_nibble(unsigned char *b);
 void eos_move_high_nibble_to_low_nibble(unsigned char *b);
 void eos_add_a_to_hl(char a, unsigned short *b);
 
+// The EOS returns a variety of error codes. Several of these are errors returned by the 
+// Device Control Blocks. In order to interpret these from the table below, the high bit 
+// must be stripped with an AND 7F.
+#define EOS_ERR_NONE           0
+#define EOS_ERR_DCB_NOT_FOUND  1 
+#define EOS_ERR_DCB_BUSY       2
+#define EOS_ERR_DCB_IDLE       3
+#define EOS_ERR_NO_DATE        4
+#define EOS_ERR_NO_FILE        5
+#define EOS_ERR_FILE_EXISTS    6 // or printer busy
+#define EOS_ERR_NO_FCB         7
+#define EOS_ERR_MATCH          8 // or file incompatible
+#define EOS_ERR_BAD_FNUM       9 // bad file number (greater than 2).
+#define EOS_ERR_EOF_ERR       10
+#define EOS_ERR_TOO_BIG       11
+#define EOS_ERR_FULL_DIR      12 // or no key pressed on keyboard read
+#define EOS_ERR_FULL_TAPE     13 // Storage media full
+#define EOS_ERR_FILE_NM       14 // File number error
+#define EOS_ERR_RENAME        15
+#define EOS_ERR_DELETE        16
+#define EOS_ERR_RANGE         17 // or bad mode
+#define EOS_ERR_CANT_SYNC1    18 // Synchronize error on clock
+#define EOS_ERR_CANT_SYNC2    19 // Synchronize error byte 2
+#define EOS_ERR_PRT           20 
+#define EOS_ERR_RQ_TP_STAT    21 // Media status error
+#define EOS_ERR_DEVICE_DEPD   22 // Device error, usually with tapes or disks
+#define EOS_ERR_PROG_NON_EXIST 23 //Program doesn't exist
+#define EOS_ERR_NO_DIR        24 // Storage medium fails directory validity check
+#define EOS_ERR_TIMEOUT       0x9B // ??? 27 Device time out
+
 #endif /* EOS_H */

--- a/src/eos_check_directory_for_file.c
+++ b/src/eos_check_directory_for_file.c
@@ -7,13 +7,13 @@
  * @return Error code, non-zero = not found
 */
 
-unsigned char eos_check_directory_for_file(const char *filename, unsigned long *block)
+unsigned char eos_check_directory_for_file(const char *filename, unsigned long *block, unsigned char device_number)
 {
   Z80_registers r;
 
 // 5231 ;*********************************************************************************
 // 5232 ;
-// 5233 ; SCAN_FOR_FILE  -- Look  inthe directory for a file name.
+// 5233 ; SCAN_FOR_FILE  -- Look  in the directory for a file name.
 // 5234 ;                Reads each block of the directory into a buffer
 // 5235 ;                (in the system’s FCB) and scans through for a
 // 5236 ;                match with the caller’s string.
@@ -32,6 +32,7 @@ unsigned char eos_check_directory_for_file(const char *filename, unsigned long *
 // 5249 ;*********************************************************************************
 
   r.UWords.HL = filename;
+  r.Bytes.A = device_number;
   
   AsmCall(0xFCFC,&r,REGS_ALL,REGS_ALL);
 

--- a/src/eos_console_display_regular.c
+++ b/src/eos_console_display_regular.c
@@ -5,7 +5,7 @@
  * @param c Character to display 
  */
 
-void eos_console_display_regular(char c)
+void eos_console_display_regular(char c, unsigned char col, unsigned char row)
 {
   Z80_registers r;
 
@@ -19,13 +19,15 @@ void eos_console_display_regular(char c)
 // 7427    ;
 // 7428    ;  optionally
 // 7429    ;   E  - Y location to goto (must be in window)
-// 7430    ;   O  - X location to goto (must be in window)
+// 7430    ;   D  - X location to goto (must be in window)
 // 7431    ;
 // 7432    ;
 // 7433    ;   Saves   all   registers
 // 7434    ;
 
   r.Bytes.A = c;
-  
+  r.Bytes.D = col;
+  r.Bytes.E = row;
+
   AsmCall(0xFC33,&r,REGS_ALL,REGS_ALL);
 }

--- a/src/eos_console_display_special.c
+++ b/src/eos_console_display_special.c
@@ -21,7 +21,7 @@ void eos_console_display_special(char c, unsigned char col, unsigned char row)
 // 7427    ;
 // 7428    ;  optionally
 // 7429    ;   E  - Y location to goto (must be in window)
-// 7430    ;   O  - X location to goto (must be in window)
+// 7430    ;   D  - X location to goto (must be in window)
 // 7431    ;
 // 7432    ;
 // 7433    ;   Saves   all   registers

--- a/src/eos_end_print_buffer.c
+++ b/src/eos_end_print_buffer.c
@@ -9,6 +9,7 @@
 unsigned char eos_end_print_buffer(char c)
 {
   Z80_registers r;
+  
 // 7208  ;*************************************************************************************************************
 // 7209  ;*
 // 7210  ;*        __END_PR_BUFF CHECKS THE DCB COMM/STATUS BYTE AND RETURNS THE  RESULT

--- a/src/eos_end_read_character_device.c
+++ b/src/eos_end_read_character_device.c
@@ -11,21 +11,18 @@ unsigned char eos_end_read_character_device(unsigned char dev)
   
   r.Bytes.A = dev;
 
-// 9173 ;******************************************************************************************
-// 9174 ;* THIS ROUTINE WILL INITIATE A READ COMMAND ON A CHARACTER DEVICE.   THE
-// 9175 ;* ROUTINE WILL WAIT FOR THE COMMAND TO BE COMPLETED.    IF THE COMMAND
-// 9176 ;* COMPLETED WITH NO ERRORS, THEN THE FLAG WILL BE ZERO. IF THERE
-// 9177 ;* WERE ERRORS   THEN THE FLAG WILL BE NON-ZERO.
-// 9178 ;*       INPUT:   A ==>   DEVICE  ID
-// 9179 ;*                DE =>   DESTINATION  ADDRESS
-// 9180 ;*                BC =>   NUMBER  OF BYTES TO READ
-// 9161 ;*      OUTPUT:
-// 9182 ;*                CONDITION FLAGS
-// 9183 ;*                        Z:       NO ERROR
-// 9184 ;*                                 A ===> KEY READ
-// 9185 ;*                       NZ:       ERROR OCCURED
-// 9186 ;*                                 A ===> ERROR CODE
-// 9187 ;******************************************************************************************
+// 928O   ;*****************************************************************************
+// 9281   ;* THIS ROUTINE WILL CHECK THE  DEVICES DCB COM/STATUS BYTE AND RETURN
+// 9282   ;* THE RESULT OF THE CHECK.
+// 9283   ;*      INPUT:  A  ===> DEVICE  ID
+// 9284   ;*      OUTPUT: CONDITION FLAGS
+// 9285   ;*              C :     COMMAND HAS FINISHED
+// 9286   ;*             NC :     COMMAND HAS NOT BEEN PROCESSED
+// 9287   ;«              Z :     NO ERROR OCCURED
+// 9288   ;*             NZ :      ERROR OCCURED
+// 9289   ;*                      A ===> ERROR CODE
+// 9290   ;*
+// 9291   ;*****************************************************************************
   
   AsmCall(0xFC48,&r,REGS_ALL,REGS_ALL);
   

--- a/src/eos_file_manager_init.c
+++ b/src/eos_file_manager_init.c
@@ -7,7 +7,7 @@
  * @return pointer to three FCB entries
  */
 
-FCB* eos_file_manager_init(void *fcb_buf)
+void eos_file_manager_init(void *fcb_buf, void *fcs_buf)
 {
   Z80_registers r;
 
@@ -23,8 +23,9 @@ FCB* eos_file_manager_init(void *fcb_buf)
 // 5207   ;*************************************************************************************************************
 
   r.UWords.DE = fcb_buf;
+  r.UWords.HL = fcs_buf;
   
   AsmCall(0xFCBA,&r,REGS_ALL,REGS_ALL);
 
-  return (FCB *)r.UWords.HL;
+  return;
 }

--- a/src/eos_find_file_1.c
+++ b/src/eos_find_file_1.c
@@ -9,7 +9,7 @@
  * @return Error code, non-zero = not found
 */
 
-unsigned char eos_find_file_1(const char *filename, DirectoryEntry *entry, unsigned long *block)
+unsigned char eos_find_file_1(const char *filename, DirectoryEntry *entry, unsigned long *block, unsigned char device_number)
 {
   Z80_registers r;
 
@@ -17,8 +17,8 @@ unsigned char eos_find_file_1(const char *filename, DirectoryEntry *entry, unsig
 
 // 3516    ;-------------------------------------------------------------------------------------------------
 // 3517    ;
-// 3518    ;  __QUERY FILE -- Read the file’s directory entry.  (USES STRCMP FOR FILE NAME COMPARISIONS)
-// 3519    ;  __FILE QUERY -- SAME AS ABOVE BUT SETS UP SCAN_FOR_FILE FOR BASE COMPARES ( USES BASECMP )
+// 3518    ;  __QUERY_FILE -- Read the file’s directory entry.  (USES STRCMP FOR FILE NAME COMPARISIONS)
+// 3519    ;  __FILE_QUERY -- SAME AS ABOVE BUT SETS UP SCAN_FOR_FILE FOR BASE COMPARES ( USES BASECMP )
 // 3520    ;
 // 3521    ;  CALLING PARAMETERS:        Device number in A
 // 3522    ;                             address of name string in DE
@@ -31,6 +31,7 @@ unsigned char eos_find_file_1(const char *filename, DirectoryEntry *entry, unsig
 // 3529    ;
 // 3530    ;-------------------------------------------------------------------------------------------------
 
+  r.Bytes.A = device_number;
   r.UWords.DE = filename;
   r.UWords.HL = entry;
   

--- a/src/eos_find_file_2.c
+++ b/src/eos_find_file_2.c
@@ -9,7 +9,7 @@
  * @return Error code, non-zero = not found
 */
 
-unsigned char eos_find_file_2(const char *filename, DirectoryEntry *entry, unsigned long *block)
+unsigned char eos_find_file_2(const char *filename, DirectoryEntry *entry, unsigned long *block, unsigned char device_number)
 {
   Z80_registers r;
 
@@ -31,7 +31,7 @@ unsigned char eos_find_file_2(const char *filename, DirectoryEntry *entry, unsig
 // 3529    ;
 // 3530    ;-------------------------------------------------------------------------------------------------
 
-
+  r.Bytes.A = device_number;
   r.UWords.DE = filename;
   r.UWords.HL = entry;
   

--- a/src/eos_put_vram.c
+++ b/src/eos_put_vram.c
@@ -28,7 +28,7 @@ unsigned short eos_put_vram(unsigned char table, unsigned short first, void* buf
 // 1602  ;
 // 1603  ;   Entry:               A  -  table code (see above)
 // 1604  ;                        DE -  starting index into the table
-// 1605  ;                        Hi -  address of user buffer
+// 1605  ;                        HL -  address of user buffer
 // 1606  ;                        IY -  block size (or byte count)
 // 1607  ;
 // 1608  ;   Exit:                None.

--- a/src/eos_read_block.c
+++ b/src/eos_read_block.c
@@ -20,7 +20,7 @@ unsigned char eos_read_block(unsigned char dev, unsigned long blockno, void* buf
 // 5842 ;*                2)    REQUESTS FOR THE STATUS
 // 5843 ;*                3)    AND SENDS ANOTHER READ TO THE DEVICE
 // 5844 ;*
-// 5845 ;*      INPUT:    SAME AS FOR  _RD_1_ BLOCK
+// 5845 ;*      INPUT:    SAME AS FOR  _RD_1_BLOCK
 // 5846 ;*                A          DEVICE ID
 // 5847 ;*                           LOW NIBBLE   -  DEVICE ADDRESS
 // 5848 ;*                           HI NIBBLE    -  SECONDARY DEVICE ID

--- a/src/eos_read_game_controller.c
+++ b/src/eos_read_game_controller.c
@@ -28,7 +28,7 @@ void eos_read_game_controller(unsigned char controllers, void* decode)
 // 2278   ;Stack Usage:
 // 2279   ;  will use 4 words   (2 pushes,  2  call)
 // 2280   ;
-// 2281   ;Calis:
+// 2281   ;Calls:
 // 2282   ;  __DECODER
 // 2283   ;  DEBOUNCE
 // 2284   ;  READ_N_DEBOUNCE      (a routine that is nested in _POLLER)

--- a/src/eos_request_device_status.c
+++ b/src/eos_request_device_status.c
@@ -15,7 +15,7 @@ unsigned char eos_request_device_status(unsigned char dev, DCB *dcb)
 // 6628  ;********************************************************************************************
 // 6629  ;* THIS ROUTINE WILL INITIATE A STATUS REQUEST COMMAND, AND WILL RETURN
 // 6630  ;* THE RESULT OF THE COMMAND.
-// 6631  ;*      INPUT:    A==>     DEVICE  ID
+// 6631  ;*      INPUT:    A ==> DEVICE  ID
 // 6632  ;*      OUTPUT:   CONDITION BITS
 // 6633  ;*                Z:       NO ERRORS
 // 6634  ;*                         IY CONTAINS START ADDRESS OF DCB

--- a/src/eos_update_file_in_directory.c
+++ b/src/eos_update_file_in_directory.c
@@ -13,10 +13,6 @@ unsigned char eos_update_file_in_directory(unsigned char dev, const char *filena
 {
   Z80_registers r;
 
-  r.Bytes.A = dev;
-  r.UWords.DE = filename;
-  r.UWords.HL = fcb;
-  
 // 3583   ;-----------------------------------------------------------------
 // 3584   ;
 // 3585   ;  _SET_FILE    --   Re-write the file’s directory entry.
@@ -25,12 +21,16 @@ unsigned char eos_update_file_in_directory(unsigned char dev, const char *filena
 // 3588   ;                           address of name string in DE
 // 3589   ;                           address of buffer in HL
 // 3590   ;
-// 3591   ; EXIT  PARAMETERS:      tf no  errors    --  Z = 1; A = 0;
+// 3591   ; EXIT  PARAMETERS:      if no  errors    --  Z = 1; A = 0;
 // 3592   ;                             directory entry updated
 // 3593   ;                        if errors        --  Z = 0; A =  error code;
 // 3594   ;                             directory entry unchanged
 // 3595   ;
 // 3596   ;-----------------------------------------------------------------
+
+  r.Bytes.A = dev;
+  r.UWords.DE = filename;
+  r.UWords.HL = fcb;
 
   AsmCall(0xFCCF,&r,REGS_ALL,REGS_ALL);
 

--- a/src/eos_write_vdp_register.c
+++ b/src/eos_write_vdp_register.c
@@ -20,7 +20,7 @@ void eos_write_vdp_register(unsigned char reg, unsigned char val)
 // 1377   ;   Exit:                 if register number = 0 or 1, the  respective byte
 // 1378   ;                         of the VDP_MODE_WORD is updated.
 // 1379   ;
-                            1380   ;   Registers     used:   A,BC,E
+// 1380   ;   Registers     used:   A,BC,E
 
   r.Bytes.B = reg;
   r.Bytes.C = val;


### PR DESCRIPTION
eos_check_directory_for_file - device number; should have been passed in A, defaulting to zero
eos_console_display_regular  - Need to add x,y
eos_end_read_character_device - incorrect comment added; fixed
eos_file_manager_init - added fcs_buffer.  Changed return result to void
eos_find_file_1 - added device number; should have been passed in A, defaulting to zero
eos_find_file_2 - added device number; should have been passed in A, defaulting to zero